### PR TITLE
docs(changelog): use full README filename in v1.0.1 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Installer UX improvements. No application code changes.
 - `dmg-assets/generate-background.swift` generator script invoked from the release workflow
 
 ### Changed
-- Release workflow (`.github/workflows/release.yml`) copies the README and renders the background before calling `create-dmg`
+- Release workflow (`.github/workflows/release.yml`) copies the `README - HOW TO OPEN.txt` and renders the background before calling `create-dmg`
 
 ## [1.0.0] — 2026-05-10
 


### PR DESCRIPTION
## Summary
- Updates the CHANGELOG entry: use full backticked `README - HOW TO OPEN.txt` in the v1.0.1 Changed entry for consistency with the Added section and to avoid ambiguity with the project README.

## Test plan
- [x] Visual diff of CHANGELOG.md