### PR TITLE
docs(changelog): include dmg-assets path for README filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Installer UX improvements. No application code changes.
 - `dmg-assets/generate-background.swift` generator script invoked from the release workflow
 
 ### Changed
-- Release workflow (`.github/workflows/release.yml`) copies the `README - HOW TO OPEN.txt` and renders the background before calling `create-dmg`
+- Release workflow (`.github/workflows/release.yml`) copies the `dmg-assets/README - HOW TO OPEN.txt` and renders the background before calling `create-dmg`
 
 ## [1.0.0] — 2026-05-10
 


### PR DESCRIPTION
## Summary
- Updates the previous CHANGELOG entry: prefix the README filename with its directory (`dmg-assets/`) for consistency with the other v1.0.1 file references.

## Test plan
- [x] Visual diff review