### PR TITLE
docs: CHANGELOG entry for v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to SystemEQ for Mac are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] — 2026-05-16
+
+Performance follow-up to v1.0.2.
+
+### Changed
+- `ProjectMHelper` scans ~9 795 preset files on a `.userInitiated` queue instead of the main thread, eliminating the UI hang seen on first run (#8)
+- Preset archive extraction filters out macOS-generated metadata folders (`__MACOSX`, dotfiles) when locating the content root (#8)
+
 ## [1.0.2] — 2026-05-16
 
 Bug-fix release.
 
 ### Fixed
-- Visualizer launched with `0 presets` because `~/Library/Application Support/SystemEQ/presets/` was never provisioned by the installer or the Cask — only projectM's idle preset rendered and the category picker was empty. `ProjectMHelper` now downloads `presets-cream-of-the-crop` on first run when the directory is empty, then populates the playlist without a restart
+- Visualizer launched with `0 presets` because `~/Library/Application Support/SystemEQ/presets/` was never provisioned by the installer or the Cask — only projectM's idle preset rendered and the category picker was empty. `ProjectMHelper` now downloads `presets-cream-of-the-crop` on first run when the directory is empty, then populates the playlist without a restart (#5)
 
 ## [1.0.1] — 2026-05-16
 


### PR DESCRIPTION
## Summary
- Document the visualizer scan-off-main-thread + archive-root-filter changes shipped in #8.
- Adds PR reference to the v1.0.2 entry for traceability.