### PR TITLE
fix: harden archive root selection and changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Performance follow-up to v1.0.2.
 
 ### Changed
-- `ProjectMHelper` scans ~9 795 preset files on a `.userInitiated` queue instead of the main thread, eliminating the UI hang seen on first run (#8)
+- `ProjectMHelper` scans ~9,800 preset files on a `.userInitiated` queue instead of the main thread, eliminating the UI hang seen on first run (#8)
 - Preset archive extraction filters out macOS-generated metadata folders (`__MACOSX`, dotfiles) when locating the content root (#8)
 
 ## [1.0.2] — 2026-05-16

--- a/ProjectMHelper/ProjectMHelperApp.swift
+++ b/ProjectMHelper/ProjectMHelperApp.swift
@@ -563,11 +563,14 @@ class VisualizerController: NSObject {
         // Archive root is `presets-cream-of-the-crop-master/` — move its contents into basePath.
         // Skip macOS-generated metadata folders (`__MACOSX`) and dotfiles so we don't pick them as the root.
         let fm = FileManager.default
-        guard let roots = try? fm.contentsOfDirectory(at: stagingDir, includingPropertiesForKeys: nil),
-              let archiveRoot = roots.first(where: {
-                  let name = $0.lastPathComponent
-                  return !name.hasPrefix("__") && !name.hasPrefix(".")
-              }) else {
+        guard let roots = try? fm.contentsOfDirectory(
+            at: stagingDir, includingPropertiesForKeys: [.isDirectoryKey]
+        ),
+            let archiveRoot = roots.first(where: {
+                let name = $0.lastPathComponent
+                let isDir = (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+                return isDir && !name.hasPrefix("__") && !name.hasPrefix(".")
+            }) else {
             print("[ProjectMHelper] Extracted archive is empty")
             return
         }


### PR DESCRIPTION
## Summary
- **PR #8 follow-up**: `extractPresetArchive` now requires the candidate archive root to be a directory, so a stray `README.md` / `LICENSE` at the archive top level cannot be picked as the presets root.
- **PR #9 follow-up**: switched `~9 795` → `~9,800` in CHANGELOG v1.0.3 (comma thousands separator, rounded to match the approximation symbol).

## Test plan
- [x] Pre-commit hooks (SwiftFormat + SwiftLint) pass
- [ ] Local build of ProjectMHelper succeeds
- [ ] Fresh-install dry run (delete presets dir → relaunch → presets repopulate)