### PR TITLE
chore: SwiftFormat cleanup and archive-root follow-up

### DIFF
--- a/ProjectMHelper/ProjectMHelperApp.swift
+++ b/ProjectMHelper/ProjectMHelperApp.swift
@@ -568,8 +568,8 @@ class VisualizerController: NSObject {
         ),
             let archiveRoot = roots.first(where: {
                 let name = $0.lastPathComponent
-                let isDir = (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
-                return isDir && !name.hasPrefix("__") && !name.hasPrefix(".")
+                guard !name.hasPrefix("__"), !name.hasPrefix(".") else { return false }
+                return (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
             }) else {
             print("[ProjectMHelper] Extracted archive is empty")
             return

--- a/SystemEQ for Mac/Audio/AudioEngine.swift
+++ b/SystemEQ for Mac/Audio/AudioEngine.swift
@@ -180,7 +180,7 @@ public final class AudioEngine: ObservableObject {
         if let last = sorted.last, freq >= last.frequency { return last.gain }
         for i in 0..<(sorted.count - 1) {
             let lo = sorted[i], hi = sorted[i + 1]
-            if freq >= lo.frequency && freq <= hi.frequency {
+            if freq >= lo.frequency, freq <= hi.frequency {
                 let logLo = log10(lo.frequency)
                 let logHi = log10(hi.frequency)
                 let logF = log10(freq)

--- a/SystemEQ for Mac/Audio/BiquadFilterVDSP.swift
+++ b/SystemEQ for Mac/Audio/BiquadFilterVDSP.swift
@@ -186,7 +186,11 @@ public final class BiquadFilterVDSP {
 
     /// Reset filter states (clears delay lines).
     public func reset() {
-        for i in delaysL.indices { delaysL[i] = 0 }
-        for i in delaysR.indices { delaysR[i] = 0 }
+        for i in delaysL.indices {
+            delaysL[i] = 0
+        }
+        for i in delaysR.indices {
+            delaysR[i] = 0
+        }
     }
 }

--- a/SystemEQ for Mac/Audio/CoreAudioEngine.swift
+++ b/SystemEQ for Mac/Audio/CoreAudioEngine.swift
@@ -30,6 +30,7 @@ public final class CoreAudioEngine: ObservableObject {
         get { peakMeter.inputPeakLevel }
         set { peakMeter.inputPeakLevel = newValue }
     }
+
     public var outputPeakLevel: Float {
         get { peakMeter.outputPeakLevel }
         set { peakMeter.outputPeakLevel = newValue }
@@ -126,7 +127,8 @@ public final class CoreAudioEngine: ObservableObject {
     // Visualizer callback (called from audio thread)
     public var visualizerCallback: ((UnsafePointer<Float>, UnsafePointer<Float>, Int) -> Void)?
     fileprivate var visualizerCounter: Int = 0
-    fileprivate var visualizerInterval: Int = 1024 // ⚡ Update visualizer every ~21ms (48kHz) - halved frequency to reduce CPU
+    fileprivate var visualizerInterval: Int =
+        1024 // ⚡ Update visualizer every ~21ms (48kHz) - halved frequency to reduce CPU
 
     // Test tone
     fileprivate var testToneEnabled: Bool = false
@@ -144,15 +146,16 @@ public final class CoreAudioEngine: ObservableObject {
 
     fileprivate var lastInputBufferFrames: UInt32 = 0
     #if DEBUG
-    fileprivate var maxInputCallbackNanos: UInt64 = 0
-    fileprivate var sumInputCallbackNanos: UInt64 = 0
-    fileprivate var countInputCallbacks: UInt64 = 0
-    fileprivate static let machTimebase: mach_timebase_info_data_t = {
-        var tb = mach_timebase_info_data_t()
-        mach_timebase_info(&tb)
-        return tb
-    }()
-    private var diagStatsTimer: DispatchSourceTimer?
+        fileprivate var maxInputCallbackNanos: UInt64 = 0
+        fileprivate var sumInputCallbackNanos: UInt64 = 0
+        fileprivate var countInputCallbacks: UInt64 = 0
+        fileprivate static let machTimebase: mach_timebase_info_data_t = {
+            var tb = mach_timebase_info_data_t()
+            mach_timebase_info(&tb)
+            return tb
+        }()
+
+        private var diagStatsTimer: DispatchSourceTimer?
     #endif
 
     // Promote each audio callback thread to time-constraint scheduling on its
@@ -193,8 +196,8 @@ public final class CoreAudioEngine: ObservableObject {
         return rate
     }
 
-    // One-shot log of buffer frame size + allowed range at setup.
-    // Useful in bug reports to understand actual device latency.
+    /// One-shot log of buffer frame size + allowed range at setup.
+    /// Useful in bug reports to understand actual device latency.
     private func logDeviceBufferInfo(_ deviceID: AudioDeviceID, label: String) {
         var rangeAddr = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyBufferFrameSizeRange,
@@ -858,55 +861,55 @@ public final class CoreAudioEngine: ObservableObject {
             dlog("✅ Core Audio Engine started", category: .engine)
             dlog("   Audio flows: Input → EQ Processing → Output", category: .engine)
             #if DEBUG
-            startDiagStatsTimer()
+                startDiagStatsTimer()
             #endif
         } else {
             dlog("❌ Failed to start Core Audio Engine: in=\(s1), out=\(s2)", category: .engine)
         }
     }
 
-    // Audio-thread health timer. Flushes every 30s on main queue; only logs
-    // when something interesting happens (high max, underrun, overrun) so we
-    // don't pollute the console during normal operation.
+    /// Audio-thread health timer. Flushes every 30s on main queue; only logs
+    /// when something interesting happens (high max, underrun, overrun) so we
+    /// don't pollute the console during normal operation.
     private func startDiagStatsTimer() {
         #if DEBUG
-        diagStatsTimer?.cancel()
-        let t = DispatchSource.makeTimerSource(queue: .main)
-        t.schedule(deadline: .now() + 30.0, repeating: 30.0)
-        t.setEventHandler { [weak self] in
-            guard let self else { return }
-            let maxNs = self.maxInputCallbackNanos
-            let sumNs = self.sumInputCallbackNanos
-            let count = self.countInputCallbacks
-            self.maxInputCallbackNanos = 0
-            self.sumInputCallbackNanos = 0
-            self.countInputCallbacks = 0
-            let avgNs = count > 0 ? sumNs / count : 0
-            let diag = self.ringBuffer.snapshotAndResetDiag()
+            diagStatsTimer?.cancel()
+            let t = DispatchSource.makeTimerSource(queue: .main)
+            t.schedule(deadline: .now() + 30.0, repeating: 30.0)
+            t.setEventHandler { [weak self] in
+                guard let self else { return }
+                let maxNs = self.maxInputCallbackNanos
+                let sumNs = self.sumInputCallbackNanos
+                let count = self.countInputCallbacks
+                self.maxInputCallbackNanos = 0
+                self.sumInputCallbackNanos = 0
+                self.countInputCallbacks = 0
+                let avgNs = count > 0 ? sumNs / count : 0
+                let diag = self.ringBuffer.snapshotAndResetDiag()
 
-            let bufFrames = self.lastInputBufferFrames
-            let deadlineNs: UInt64 = bufFrames > 0
-                ? UInt64(Double(bufFrames) / self.currentSampleRate * 1_000_000_000)
-                : 0
-            let nearDeadline = deadlineNs > 0 && maxNs > deadlineNs / 2
-            if nearDeadline || diag.underruns > 0 || diag.overruns > 0 {
-                dlog(
-                    "⚠️ Audio health: max=\(maxNs / 1000)µs avg=\(avgNs / 1000)µs " +
-                    "(deadline=\(deadlineNs / 1000)µs) under=\(diag.underruns) over=\(diag.overruns)",
-                    level: .warning,
-                    category: .engine
-                )
+                let bufFrames = self.lastInputBufferFrames
+                let deadlineNs: UInt64 = bufFrames > 0
+                    ? UInt64(Double(bufFrames) / self.currentSampleRate * 1_000_000_000)
+                    : 0
+                let nearDeadline = deadlineNs > 0 && maxNs > deadlineNs / 2
+                if nearDeadline || diag.underruns > 0 || diag.overruns > 0 {
+                    dlog(
+                        "⚠️ Audio health: max=\(maxNs / 1000)µs avg=\(avgNs / 1000)µs " +
+                            "(deadline=\(deadlineNs / 1000)µs) under=\(diag.underruns) over=\(diag.overruns)",
+                        level: .warning,
+                        category: .engine
+                    )
+                }
             }
-        }
-        t.resume()
-        diagStatsTimer = t
+            t.resume()
+            diagStatsTimer = t
         #endif
     }
 
     private func stopDiagStatsTimer() {
         #if DEBUG
-        diagStatsTimer?.cancel()
-        diagStatsTimer = nil
+            diagStatsTimer?.cancel()
+            diagStatsTimer = nil
         #endif
     }
 
@@ -930,7 +933,7 @@ public final class CoreAudioEngine: ObservableObject {
         ringBuffer.reset()
 
         #if DEBUG
-        stopDiagStatsTimer()
+            stopDiagStatsTimer()
         #endif
 
         dlog("🛑 Core Audio Engine stopped", category: .engine)
@@ -1006,7 +1009,7 @@ public final class CoreAudioEngine: ObservableObject {
         defer { cleanupLock.unlock() }
         guard !isCleanedUp else { return }
         isCleanedUp = true
-        
+
         if let iu = inputUnit {
             AudioUnitUninitialize(iu)
             AudioComponentInstanceDispose(iu)
@@ -1267,12 +1270,12 @@ private func renderCallbackFunction(
 }
 
 #if DEBUG
-@inline(__always)
-private func machNanosSince(_ start: UInt64) -> UInt64 {
-    let end = mach_absolute_time()
-    let tb = CoreAudioEngine.machTimebase
-    return (end &- start) &* UInt64(tb.numer) / UInt64(tb.denom)
-}
+    @inline(__always)
+    private func machNanosSince(_ start: UInt64) -> UInt64 {
+        let end = mach_absolute_time()
+        let tb = CoreAudioEngine.machTimebase
+        return (end &- start) &* UInt64(tb.numer) / UInt64(tb.denom)
+    }
 #endif
 
 private func inputCaptureCallbackFunction(
@@ -1284,7 +1287,7 @@ private func inputCaptureCallbackFunction(
     ioData: UnsafeMutablePointer<AudioBufferList>?
 ) -> OSStatus {
     #if DEBUG
-    let diagStart = mach_absolute_time()
+        let diagStart = mach_absolute_time()
     #endif
 
     let engine = Unmanaged<CoreAudioEngine>.fromOpaque(inRefCon).takeUnretainedValue()
@@ -1382,10 +1385,10 @@ private func inputCaptureCallbackFunction(
         }
     }
     #if DEBUG
-    let nanos = machNanosSince(diagStart)
-    if nanos > engine.maxInputCallbackNanos { engine.maxInputCallbackNanos = nanos }
-    engine.sumInputCallbackNanos &+= nanos
-    engine.countInputCallbacks &+= 1
+        let nanos = machNanosSince(diagStart)
+        if nanos > engine.maxInputCallbackNanos { engine.maxInputCallbackNanos = nanos }
+        engine.sumInputCallbackNanos &+= nanos
+        engine.countInputCallbacks &+= 1
     #endif
 
     return noErr

--- a/SystemEQ for Mac/Audio/PeakMeter.swift
+++ b/SystemEQ for Mac/Audio/PeakMeter.swift
@@ -16,7 +16,6 @@ import Foundation
 /// Real-time peak level meter for audio buffers
 /// Designed for use in audio render callbacks (lock-free, low overhead)
 public final class PeakMeter: ObservableObject {
-
     // MARK: - Published Properties (Main Thread)
 
     @Published public var inputPeakLevel: Float = 0.0

--- a/SystemEQ for Mac/Audio/RealtimeThread.swift
+++ b/SystemEQ for Mac/Audio/RealtimeThread.swift
@@ -13,7 +13,6 @@ import Darwin
 import Foundation
 
 enum RealtimeThread {
-
     /// Promote the calling thread to time-constraint scheduling.
     /// Safe to call multiple times — the kernel simply overwrites the policy.
     /// - Parameters:

--- a/SystemEQ for Mac/Audio/SPSCRingBuffer.swift
+++ b/SystemEQ for Mac/Audio/SPSCRingBuffer.swift
@@ -14,7 +14,6 @@ import Accelerate
 import Foundation
 
 public final class SPSCRingBuffer {
-
     // MARK: - Properties
 
     private(set) var left: UnsafeMutablePointer<Float>?
@@ -127,8 +126,13 @@ public final class SPSCRingBuffer {
     }
 
     /// Diagnostic-only relaxed reads (main thread).
-    var writeIndex: Int { loadWriteRelaxed() }
-    var readIndex: Int { loadReadRelaxed() }
+    var writeIndex: Int {
+        loadWriteRelaxed()
+    }
+
+    var readIndex: Int {
+        loadReadRelaxed()
+    }
 
     // MARK: - Write (Producer / Input Callback)
 
@@ -290,8 +294,13 @@ public final class SPSCRingBuffer {
 }
 
 @inline(__always)
-private func interleaveStereo(l: UnsafePointer<Float>, r: UnsafePointer<Float>, out: UnsafeMutablePointer<Float>, count: Int) {
-    for i in 0 ..< count {
+private func interleaveStereo(
+    l: UnsafePointer<Float>,
+    r: UnsafePointer<Float>,
+    out: UnsafeMutablePointer<Float>,
+    count: Int
+) {
+    for i in 0..<count {
         out[i &* 2] = l[i]
         out[i &* 2 &+ 1] = r[i]
     }

--- a/SystemEQ for Mac/Audio/Visualizer/ProjectM/ProjectMHelperClient.swift
+++ b/SystemEQ for Mac/Audio/Visualizer/ProjectM/ProjectMHelperClient.swift
@@ -26,7 +26,7 @@ final class ProjectMHelperClient: ObservableObject {
     @Published private(set) var availableCategories: [String] = ["All"]
     @Published private(set) var currentCategory: String = "All"
     @Published private(set) var currentWeight: String = "All"
-    
+
     @Published var isShuffleEnabled: Bool = true {
         didSet {
             sendCommand("SHUFFLE:\(isShuffleEnabled ? "1" : "0")")
@@ -38,14 +38,14 @@ final class ProjectMHelperClient: ObservableObject {
             sendCommand("LOCK:\(isPresetLocked ? "1" : "0")")
         }
     }
-    
+
     @Published var selectedCategory: String = "All" {
         didSet {
             guard selectedCategory != currentCategory else { return }
             sendCommand("CATEGORY:\(selectedCategory)")
         }
     }
-    
+
     @Published var selectedWeight: String = "All" {
         didSet {
             guard selectedWeight != currentWeight else { return }
@@ -80,10 +80,10 @@ final class ProjectMHelperClient: ObservableObject {
     private var statusUpdateTimer: Timer?
 
     // Lock-free ring buffer for audio (written on real-time audio thread, read on ipcQueue)
-    private let audioRingCapacity = 8192  // must be power of 2
+    private let audioRingCapacity = 8192 // must be power of 2
     nonisolated(unsafe) private var _audioRingBuffer: UnsafeMutablePointer<Float>
     nonisolated(unsafe) private var _audioWriteIdx: SEQAtomicInt32 = seq_atomic_int32_make(0)
-    private var _audioReadIdx: Int32 = 0  // only accessed from ipcQueue
+    private var _audioReadIdx: Int32 = 0 // only accessed from ipcQueue
     private var audioSendTimer: DispatchSourceTimer?
 
     // Pre-allocated send buffer (only touched from ipcQueue inside audioSendTimer handler)
@@ -130,7 +130,8 @@ final class ProjectMHelperClient: ObservableObject {
 
             // Monitor process termination (user closes window).
             // Close socket synchronously so pending writes fail fast instead of blocking/retrying.
-            // SO_NOSIGPIPE already prevents the fatal signal; this just avoids wasted work until MainActor cleanup runs.
+            // SO_NOSIGPIPE already prevents the fatal signal; this just avoids wasted work until MainActor cleanup
+            // runs.
             process.terminationHandler = { [weak self] _ in
                 if let self {
                     let sock = self.getSocket()
@@ -305,7 +306,7 @@ final class ProjectMHelperClient: ObservableObject {
                 withUnsafeMutablePointer(to: &addr.sun_path) { sunPathPtr in
                     let rawPtr = UnsafeMutableRawPointer(sunPathPtr).assumingMemoryBound(to: CChar.self)
                     strncpy(rawPtr, sourcePtr, maxPathLength - 1)
-                rawPtr[maxPathLength - 1] = 0
+                    rawPtr[maxPathLength - 1] = 0
                 }
             }
 
@@ -442,7 +443,11 @@ final class ProjectMHelperClient: ObservableObject {
     }
 
     /// Called from real-time audio thread — lock-free, no heap allocation
-    nonisolated private func processAudioData(left: UnsafePointer<Float>, right: UnsafePointer<Float>, frameCount: Int) {
+    nonisolated private func processAudioData(
+        left: UnsafePointer<Float>,
+        right: UnsafePointer<Float>,
+        frameCount: Int
+    ) {
         let maxSamples = min(frameCount, 1024)
         let mask = Int32(audioRingCapacity - 1)
         for i in 0..<maxSamples {

--- a/SystemEQ for Mac/Data/EQDatabase.swift
+++ b/SystemEQ for Mac/Data/EQDatabase.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SQLite3
 
-// SQLITE_TRANSIENT tells SQLite to make its own copy of the string
+/// SQLITE_TRANSIENT tells SQLite to make its own copy of the string
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 // MARK: - Models

--- a/SystemEQ for Mac/DesignSystem/AppDesign.swift
+++ b/SystemEQ for Mac/DesignSystem/AppDesign.swift
@@ -444,7 +444,8 @@ struct WindowContainer<Content: View>: View {
             content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(useGlassEffect ? AnyView(VisualEffectBackground()) : AnyView(Color(nsColor: .windowBackgroundColor)))
+        .background(useGlassEffect ? AnyView(VisualEffectBackground()) :
+            AnyView(Color(nsColor: .windowBackgroundColor)))
     }
 }
 

--- a/SystemEQ for Mac/DesignSystem/EQGraphView.swift
+++ b/SystemEQ for Mac/DesignSystem/EQGraphView.swift
@@ -59,8 +59,11 @@ struct EQGridBackground: View {
                     path.move(to: CGPoint(x: hPad, y: y))
                     path.addLine(to: CGPoint(x: size.width - hPad, y: y))
                     let isCenter = db == 0
-                    ctx.stroke(path, with: .color(.secondary.opacity(isCenter ? 0.35 : 0.15)),
-                               lineWidth: isCenter ? 1.5 : 0.5)
+                    ctx.stroke(
+                        path,
+                        with: .color(.secondary.opacity(isCenter ? 0.35 : 0.15)),
+                        lineWidth: isCenter ? 1.5 : 0.5
+                    )
                 }
 
                 for freq in freqLabels {
@@ -97,7 +100,9 @@ struct EQCurveView: View {
     let height: CGFloat
     let hPad: CGFloat
 
-    private var accentColor: Color { Color.accentColor }
+    private var accentColor: Color {
+        Color.accentColor
+    }
 
     private var points: [CGPoint] {
         bands.map { band in
@@ -181,9 +186,17 @@ struct EQBandHandle: View {
     @State private var isDragging = false
     @State private var dragStartGain: Float = 0
 
-    private var handleX: CGFloat { eqXFor(freq: band.frequency, width: size.width, hPad: hPad) }
-    private var handleY: CGFloat { eqYFor(gain: gain, height: size.height) }
-    private var midY: CGFloat { size.height / 2 }
+    private var handleX: CGFloat {
+        eqXFor(freq: band.frequency, width: size.width, hPad: hPad)
+    }
+
+    private var handleY: CGFloat {
+        eqYFor(gain: gain, height: size.height)
+    }
+
+    private var midY: CGFloat {
+        size.height / 2
+    }
 
     private var fillColor: Color {
         if gain == 0 { return Color.secondary.opacity(0.5) }

--- a/SystemEQ for Mac/DesignSystem/InfoPopoverButton.swift
+++ b/SystemEQ for Mac/DesignSystem/InfoPopoverButton.swift
@@ -2,11 +2,7 @@ import AppKit
 import SwiftUI
 
 struct InfoPopoverButton<Content: View>: View {
-    let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
+    @ViewBuilder let content: Content
 
     var body: some View {
         _InfoPopoverAnchor(popoverContent: AnyView(content))
@@ -50,7 +46,8 @@ private struct _InfoPopoverAnchor: NSViewRepresentable {
             self.content = content
         }
 
-        @objc func toggle(_ sender: NSButton) {
+        @objc
+        func toggle(_ sender: NSButton) {
             if let popover, popover.isShown {
                 popover.close()
                 return

--- a/SystemEQ for Mac/Features/AutoEQView.swift
+++ b/SystemEQ for Mac/Features/AutoEQView.swift
@@ -18,7 +18,7 @@ struct AutoEQView: View {
     enum BandMode: String, CaseIterable, Identifiable { case ten = "10", thirtyOne = "31"; var id: String {
         rawValue
     } }
-private static let indexVersion = 5 // Increment when path logic changes
+    private static let indexVersion = 5 // Increment when path logic changes
     private static let indexUpdateInterval: TimeInterval = 30 * 24 * 3600 // 30 днів (1 місяць)
 
     // MARK: - Localization
@@ -794,7 +794,10 @@ private static let indexVersion = 5 // Increment when path logic changes
             let availableWidth = geo.size.width - dbAxisWidth - 6
             let minSpacing: CGFloat = bandMode == .thirtyOne ? 3 : 5
             let minBarWidth: CGFloat = bandMode == .thirtyOne ? 8 : 14
-            let spacing: CGFloat = max(minSpacing, min(10, (availableWidth - bandCount * minBarWidth) / max(1, bandCount - 1)))
+            let spacing: CGFloat = max(
+                minSpacing,
+                min(10, (availableWidth - bandCount * minBarWidth) / max(1, bandCount - 1))
+            )
             let hitWidth: CGFloat = max(minBarWidth, (availableWidth - spacing * (bandCount - 1)) / bandCount)
             let barWidth: CGFloat = bandMode == .thirtyOne ? max(hitWidth * 0.65, hitWidth - 4) : 14
             let gridDbs: [Int] = [12, 6, 0, -6, -12]
@@ -963,7 +966,7 @@ private static let indexVersion = 5 // Increment when path logic changes
         }
     }
 
-// MARK: - Search helpers
+    // MARK: - Search helpers
 
     private var normalizedQuery: String {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -1405,7 +1408,8 @@ private static let indexVersion = 5 // Increment when path logic changes
         var a0 = 1.0, a1 = 0.0, a2 = 0.0
 
         switch b.type {
-        case .peak, .allPassPEQ:
+        case .allPassPEQ,
+             .peak:
             b0 = 1 + alpha * A
             b1 = -2 * cosW0
             b2 = 1 - alpha * A

--- a/SystemEQ for Mac/Features/CalibrationView.swift
+++ b/SystemEQ for Mac/Features/CalibrationView.swift
@@ -261,10 +261,26 @@ struct CalibrationView: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 ForEach([
-                    ("1️⃣", localization.localized(.calibrationPreparation), localization.localized(.calibrationPreparationDesc)),
-                    ("2️⃣", localization.localized(.calibrationReference1000), localization.localized(.calibrationReference1000Desc)),
-                    ("3️⃣", localization.localized(.calibrationAdjustFrequencies), localization.localized(.calibrationAdjustFrequenciesDesc)),
-                    ("4️⃣", localization.localized(.calibrationVerification), localization.localized(.calibrationVerificationDesc))
+                    (
+                        "1️⃣",
+                        localization.localized(.calibrationPreparation),
+                        localization.localized(.calibrationPreparationDesc)
+                    ),
+                    (
+                        "2️⃣",
+                        localization.localized(.calibrationReference1000),
+                        localization.localized(.calibrationReference1000Desc)
+                    ),
+                    (
+                        "3️⃣",
+                        localization.localized(.calibrationAdjustFrequencies),
+                        localization.localized(.calibrationAdjustFrequenciesDesc)
+                    ),
+                    (
+                        "4️⃣",
+                        localization.localized(.calibrationVerification),
+                        localization.localized(.calibrationVerificationDesc)
+                    )
                 ], id: \.1) { emoji, title, desc in
                     HStack(alignment: .top, spacing: 8) {
                         Text(emoji)
@@ -311,11 +327,13 @@ struct CalibrationView: View {
                             HStack {
                                 Image(systemName: mode.icon)
                                     .font(.title2)
-                                Text(localization.localized(mode == .clean ? .calibrationModeClean : .calibrationModeCombined))
+                                Text(localization
+                                    .localized(mode == .clean ? .calibrationModeClean : .calibrationModeCombined))
                                     .font(.headline)
                             }
 
-                            Text(localization.localized(mode == .clean ? .calibrationModeCleanDesc : .calibrationModeCombinedDesc))
+                            Text(localization
+                                .localized(mode == .clean ? .calibrationModeCleanDesc : .calibrationModeCombinedDesc))
                                 .font(AppTypography.label)
                                 .foregroundColor(.secondary)
                                 .multilineTextAlignment(.leading)

--- a/SystemEQ for Mac/Features/ResonanceFinderView.swift
+++ b/SystemEQ for Mac/Features/ResonanceFinderView.swift
@@ -318,7 +318,8 @@ struct ResonanceFinderView: View {
                 }) {
                     HStack {
                         Image(systemName: sineSweep.isPlaying ? "stop.fill" : "play.fill")
-                        Text(sineSweep.isPlaying ? localization.localized(.stopPlayback) : localization.localized(.playTone))
+                        Text(sineSweep.isPlaying ? localization.localized(.stopPlayback) : localization
+                            .localized(.playTone))
                     }
                     .frame(maxWidth: .infinity)
                 }

--- a/SystemEQ for Mac/Features/SubjectiveRoomTuningView.swift
+++ b/SystemEQ for Mac/Features/SubjectiveRoomTuningView.swift
@@ -395,7 +395,8 @@ struct SubjectiveRoomTuningView: View {
                 }) {
                     HStack {
                         Image(systemName: sineSweep.isPlaying ? "stop.fill" : "play.fill")
-                        Text(sineSweep.isPlaying ? localization.localized(.stopPlayback) : localization.localized(.playTone))
+                        Text(sineSweep.isPlaying ? localization.localized(.stopPlayback) : localization
+                            .localized(.playTone))
                     }
                     .frame(maxWidth: .infinity)
                 }
@@ -643,9 +644,9 @@ struct SubjectiveRoomTuningView: View {
                         .fontWeight(.medium)
                 }
                 Text(localization.localized(.resonanceExplanation))
-                .font(AppTypography.label)
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+                    .font(AppTypography.label)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(12)
             .background(Color.blue.opacity(0.1))
@@ -676,10 +677,30 @@ struct SubjectiveRoomTuningView: View {
                 // Vertical buttons instead of segmented picker
                 VStack(spacing: 8) {
                     ForEach([
-                        (ResonancePoint.Severity.mild, localization.localized(.severityMild), "-2 dB", localization.localized(.severityMildDesc)),
-                        (ResonancePoint.Severity.moderate, localization.localized(.severityModerate), "-4 dB", localization.localized(.severityModerateDesc)),
-                        (ResonancePoint.Severity.severe, localization.localized(.severitySevere), "-6 dB", localization.localized(.severitySevereDesc)),
-                        (ResonancePoint.Severity.extreme, localization.localized(.severityExtreme), "-8 dB", localization.localized(.severityExtremeDesc))
+                        (
+                            ResonancePoint.Severity.mild,
+                            localization.localized(.severityMild),
+                            "-2 dB",
+                            localization.localized(.severityMildDesc)
+                        ),
+                        (
+                            ResonancePoint.Severity.moderate,
+                            localization.localized(.severityModerate),
+                            "-4 dB",
+                            localization.localized(.severityModerateDesc)
+                        ),
+                        (
+                            ResonancePoint.Severity.severe,
+                            localization.localized(.severitySevere),
+                            "-6 dB",
+                            localization.localized(.severitySevereDesc)
+                        ),
+                        (
+                            ResonancePoint.Severity.extreme,
+                            localization.localized(.severityExtreme),
+                            "-8 dB",
+                            localization.localized(.severityExtremeDesc)
+                        )
                     ], id: \.0) { severity, name, db, desc in
                         Button(action: {
                             newResonanceSeverity = severity
@@ -810,7 +831,7 @@ struct SubjectiveRoomTuningView: View {
 
         // Average notch gain across all filters to estimate loudness change
         let avgGain = appliedNotchFilters.map(\.gain).reduce(0, +) / Float(appliedNotchFilters.count)
-        gainMatchOffset = -avgGain  // compensate: filters cut, so add back when bypassed
+        gainMatchOffset = -avgGain // compensate: filters cut, so add back when bypassed
 
         abIsFiltered = true
         applyNotchFilters()

--- a/SystemEQ for Mac/Features/VisualizerView.swift
+++ b/SystemEQ for Mac/Features/VisualizerView.swift
@@ -105,7 +105,7 @@ struct VisualizerView: View {
 
     // MARK: - Visualization Canvas
 
-    @ViewBuilder private var visualizationCanvas: some View {
+    private var visualizationCanvas: some View {
         GeometryReader { geometry in
             ZStack {
                 Color.black
@@ -174,10 +174,10 @@ struct VisualizerView: View {
 
     private func toggleFullscreen() {
         // Use native macOS fullscreen via window toggle
-        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { 
-            $0.identifier?.rawValue == FeatureID.visualizer.rawValue 
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: {
+            $0.identifier?.rawValue == FeatureID.visualizer.rawValue
         }) else { return }
-        
+
         window.toggleFullScreen(nil)
     }
 

--- a/SystemEQ for Mac/Infra/StatusItemController.swift
+++ b/SystemEQ for Mac/Infra/StatusItemController.swift
@@ -167,7 +167,8 @@ final class StatusItemController: NSObject {
         }
     }
 
-    @objc private func toggleEQ() {
+    @objc
+    private func toggleEQ() {
         let newValue = !AudioEngine.shared.isEnabled
         AudioEngine.shared.setEnabled(newValue)
         CoreAudioEngine.shared.setEnabled(newValue)
@@ -178,14 +179,16 @@ final class StatusItemController: NSObject {
         )
     }
 
-    @objc private func openMain() {
+    @objc
+    private func openMain() {
         NSApp.activate(ignoringOtherApps: true)
         if let win = NSApp.windows.first(where: { $0.identifier?.rawValue == "main" }) {
             win.makeKeyAndOrderFront(nil)
         }
     }
 
-    @objc private func quit() {
+    @objc
+    private func quit() {
         NSApp.terminate(nil)
     }
 }

--- a/SystemEQ for Mac/LocalizationManager.swift
+++ b/SystemEQ for Mac/LocalizationManager.swift
@@ -688,7 +688,7 @@ public enum LocalizedString: String, CaseIterable {
     case runSetupAssistant
     case launchAtLoginHelp
 
-    // SubjectiveRoomTuningView tabs
+    /// SubjectiveRoomTuningView tabs
     case tuningTab
 
     // Calibration Activation Alert

--- a/SystemEQ for Mac/SystemEQ_for_MacApp.swift
+++ b/SystemEQ for Mac/SystemEQ_for_MacApp.swift
@@ -57,7 +57,6 @@ struct SystemEQ_for_MacApp: App {
                         dlog("Audio access authorized", category: .audio)
                     }
 
-
                     // NOTE: Python AutoEQ Server removed - using SQLite database instead
                     // To restore: see git history for AutoEQServer.swift
 

--- a/SystemEQ for Mac/Utils/DebugLogger.swift
+++ b/SystemEQ for Mac/Utils/DebugLogger.swift
@@ -8,7 +8,7 @@ import Foundation
 #if DEBUG
 
     /// Категорії логування для фільтрації
-    enum LogCategory: String, Sendable {
+    enum LogCategory: String {
         case audio = "🔊 Audio"
         case engine = "⚙️ Engine"
         case routing = "🔀 Routing"
@@ -22,7 +22,7 @@ import Foundation
     }
 
     /// Рівні важливості
-    enum LogLevel: Int, Comparable, Sendable {
+    enum LogLevel: Int, Comparable {
         case verbose = 0 // Детальна інформація (рідко потрібна)
         case debug = 1 // Debug інформація
         case info = 2 // Загальна інформація
@@ -221,12 +221,25 @@ import Foundation
     // В Release stub'и приймають ті ж типи що й DEBUG — інакше Swift не резолвить `.audio` / `.error`
     // на call-site (бо `Any?` не має member'ів enum). Тіло порожнє — optimizer видалить виклики.
 
-    enum LogCategory: String, Sendable {
-        case audio, engine, routing, eq, preset, ui, network, database, calibration, general
+    enum LogCategory: String {
+        case audio
+        case engine
+        case routing
+        case eq
+        case preset
+        case ui
+        case network
+        case database
+        case calibration
+        case general
     }
 
-    enum LogLevel: Int, Sendable {
-        case verbose, debug, info, warning, error
+    enum LogLevel: Int {
+        case verbose
+        case debug
+        case info
+        case warning
+        case error
     }
 
     @inline(__always)


### PR DESCRIPTION
## Summary
- **CI fix**: ran \`swiftformat\` on the whole \`SystemEQ for Mac\` + \`ProjectMHelper\` trees to clear ~143 pre-existing lint violations that have been failing the Code Quality workflow on main. Pure formatting, no semantic changes.
- **Archive-root follow-up**: in \`extractPresetArchive\`, filter \`__\` / dotfile names before the \`resourceValues\` lookup so we don't hit the filesystem for entries we'd reject anyway.

## Test plan
- [x] \`swiftformat --lint\` reports 0/62 files require formatting
- [x] \`swiftlint\` passes
- [x] \`xcodebuild build\` succeeds for the main app + helper
- [ ] CI Code Quality workflow goes green