### PR TITLE
docs: CHANGELOG entry for v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to SystemEQ for Mac are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] — 2026-05-16
+
+Code-quality and robustness pass. No user-facing behavior changes.
+
+### Changed
+- Preset archive root selection now requires the candidate entry to be a directory and short-circuits on filename, so a stray `README` / `LICENSE` at the archive top level cannot be picked as the presets root (#11, #12)
+- Repository-wide `swiftformat` pass to clear pre-existing violations and unblock the Code Quality CI workflow (#12)
+
 ## [1.0.3] — 2026-05-16
 
 Performance follow-up to v1.0.2.


### PR DESCRIPTION
Maintenance release documenting the post-1.0.3 code-quality fixes (PR #11, #12). No application code changes — DMG will rebuild against the same source as 1.0.3 plus the archive-root robustness tweak.