### PR TITLE
ci: publish releases directly instead of as drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,8 @@ jobs:
         with:
           name: "SystemEQ for Mac v${{ steps.version.outputs.version }}"
           tag_name: "v${{ steps.version.outputs.version }}"
-          draft: true
+          draft: false
+          make_latest: "true"
           generate_release_notes: true
           body: |
             ## SystemEQ for Mac v${{ steps.version.outputs.version }}


### PR DESCRIPTION
Fixes the issue where every release since v1.0.2 stayed in Draft state and v1.0.1 remained marked as Latest on the repo homepage.