### PR TITLE
ci: auto-bump homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,3 +139,29 @@ jobs:
             build/SystemEQ-v${{ steps.version.outputs.version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump Homebrew tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          SHA256=$(shasum -a 256 "build/SystemEQ-v${VERSION}.dmg" | awk '{print $1}')
+          echo "DMG SHA256: $SHA256"
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/denzam/homebrew-systemeq.git" tap
+          cd tap
+
+          sed -i '' -E "s/^  version \".*\"/  version \"${VERSION}\"/" Casks/systemeq.rb
+          sed -i '' -E "s/^  sha256 \".*\"/  sha256 \"${SHA256}\"/" Casks/systemeq.rb
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "Cask already at v${VERSION}, nothing to do."
+            exit 0
+          fi
+
+          git add Casks/systemeq.rb
+          git commit -m "cask: bump to v${VERSION}"
+          git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.4] — 2026-05-16
 
-Robustness pass with a code-quality cleanup.
+Robustness improvements and Code Quality cleanup.
 
 ### Changed
 - Repository-wide `swiftformat` pass to clear pre-existing violations and unblock the Code Quality CI workflow (#12)


### PR DESCRIPTION
## Summary
- Adds a step at the end of `release.yml` that, after the GitHub Release is published, recomputes the DMG SHA256, edits `Casks/systemeq.rb` in `denzam/homebrew-systemeq`, and pushes to `main`.
- Eliminates the recurring manual bump in the tap (which had drifted: tap was on v1.0.0 while app was on v1.0.4).
- Tap has already been manually catch-up bumped to v1.0.4 in a separate commit on the tap repo.

## Requirements
- Repo secret `HOMEBREW_TAP_TOKEN` (fine-grained PAT, Contents: read/write on `denzam/homebrew-systemeq`) — already configured.

## Test plan
- [ ] Next release tag (`v1.0.5+`) triggers `release.yml` and the new step pushes a `cask: bump to vX.Y.Z` commit to `denzam/homebrew-systemeq`.
- [ ] `brew update && brew upgrade --cask systemeq` picks up the new version on a clean machine.