### PR TITLE
fix: language-switch deadlock + AutoEQ text-flip (v1.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to SystemEQ for Mac are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] — 2026-05-16
+
+Critical hang fix and a rendering regression in AutoEQ.
+
+### Fixed
+
+- App froze on the main thread when switching language after opening and closing the Visualizer. `LocalizationManager.setLanguage(_:)` no longer dispatches the `@Published` write through a `queue.async(.barrier)` that could deadlock against SwiftUI layout-time reads of `localizedString(for:)`; the getter is now lock-free and the save runs on a background queue without a barrier
+- AutoEQ window labels ("Type a model name to search", "Band Mode", "Favorites", "Mapped Preview") rendered upside-down after a language change. The animated `blur(radius:)` cycle in `ViewBlurModifier` left CALayer transforms in an inconsistent state for the affected Text views; the modifier is now a no-op
+
 ## [1.0.4] — 2026-05-16
 
 Robustness improvements and Code Quality cleanup.

--- a/SystemEQ for Mac.xcodeproj/project.pbxproj
+++ b/SystemEQ for Mac.xcodeproj/project.pbxproj
@@ -356,7 +356,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.5;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4-playlist",
@@ -425,7 +425,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.5;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4-playlist",
 					"-lprojectM-4",
@@ -550,7 +550,7 @@
 					"@executable_path/../Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.5;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4",
@@ -593,7 +593,7 @@
 					"@executable_path/../Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.5;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4",
 					"-lprojectM-4-playlist",
@@ -621,7 +621,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.5;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.denzam.SystemEQ.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -639,7 +639,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.denzam.SystemEQ.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/SystemEQ for Mac/Features/AutoEQView.swift
+++ b/SystemEQ for Mac/Features/AutoEQView.swift
@@ -486,7 +486,6 @@ struct AutoEQView: View {
         .sheet(isPresented: $showAutoEQSetup) {
             autoEQSetupDialog()
         }
-        .blurOnLanguageChange()
     }
 
     // MARK: - Offline index helpers

--- a/SystemEQ for Mac/LocalizationManager.swift
+++ b/SystemEQ for Mac/LocalizationManager.swift
@@ -3833,22 +3833,20 @@ public final class LocalizationManager: ObservableObject {
     }
 
     public func setLanguage(_ language: AppLanguage) {
-        queue.async(flags: .barrier) { [weak self] in
+        let apply = { [weak self] in
             guard let self else { return }
-
-            // Save language on background queue
-            self.saveLanguage()
-
-            // Update @Published property on main thread
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.currentLanguage = language
-
-                // Post notification immediately for smooth UI transitions
-                dlog("📢 Posting languageChanged notification...", category: .general)
-                NotificationCenter.default.post(name: .languageChanged, object: nil)
-                dlog("✅ languageChanged notification posted", category: .general)
-            }
+            self.currentLanguage = language
+            dlog("📢 Posting languageChanged notification...", category: .general)
+            NotificationCenter.default.post(name: .languageChanged, object: nil)
+            dlog("✅ languageChanged notification posted", category: .general)
+        }
+        if Thread.isMainThread {
+            apply()
+        } else {
+            DispatchQueue.main.async(execute: apply)
+        }
+        queue.async { [weak self] in
+            self?.saveLanguage()
         }
     }
 
@@ -3872,15 +3870,13 @@ public final class LocalizationManager: ObservableObject {
 
     /// Get localized string for current language
     public func localizedString(for key: LocalizedString) -> String {
-        queue.sync {
-            let language = self.currentLanguage // Read currentLanguage inside the queue
-            guard let translations = LocalizationData.translations[key],
-                  let localizedString = translations[language] else {
-                dlog("⚠️ Missing translation for \(key) in \(language.rawValue)", category: .general)
-                return LocalizationData.translations[key]?[.english] ?? String(describing: key)
-            }
-            return localizedString
+        let language = currentLanguage
+        guard let translations = LocalizationData.translations[key],
+              let localizedString = translations[language] else {
+            dlog("⚠️ Missing translation for \(key) in \(language.rawValue)", category: .general)
+            return LocalizationData.translations[key]?[.english] ?? String(describing: key)
         }
+        return localizedString
     }
 
     /// Get localized string with arguments

--- a/SystemEQ for Mac/Utils/LocalizedText.swift
+++ b/SystemEQ for Mac/Utils/LocalizedText.swift
@@ -214,24 +214,8 @@ struct CrossfadeText: View {
 // MARK: - View Blur Modifier (Blur entire view on language change)
 
 struct ViewBlurModifier: ViewModifier {
-    @State private var blurRadius: CGFloat = 0
-
     func body(content: Content) -> some View {
         content
-            .blur(radius: blurRadius)
-            .onReceive(NotificationCenter.default.publisher(for: .languageChanged)) { _ in
-                // Blur out
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    blurRadius = 6
-                }
-
-                // Blur in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        blurRadius = 0
-                    }
-                }
-            }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix main-thread deadlock when changing language after opening/closing the Visualizer (`LocalizationManager` removed the barrier-async + sync-getter pair that deadlocked against SwiftUI layout reads)
- Fix four AutoEQ headings rendering upside-down after a language change (`ViewBlurModifier`'s animated blur cycle left CALayer transforms stuck; modifier is now a no-op)
- Bump `MARKETING_VERSION` to 1.0.5 and add changelog entry

## Test plan
- [x] Release build succeeds locally
- [x] Reproduced original freeze (preset → open visualizer → close → switch language) — now switches cleanly
- [x] AutoEQ labels render correctly after language switch and after window reopen