### PR TITLE
fix: drop redundant saveLanguage() in setLanguage(_:)

### DIFF
--- a/SystemEQ for Mac/LocalizationManager.swift
+++ b/SystemEQ for Mac/LocalizationManager.swift
@@ -3845,9 +3845,6 @@ public final class LocalizationManager: ObservableObject {
         } else {
             DispatchQueue.main.async(execute: apply)
         }
-        queue.async { [weak self] in
-            self?.saveLanguage()
-        }
     }
 
     private let languageKey = "AppLanguage"


### PR DESCRIPTION
## Summary
Removes redundant language persistence.

`@Published currentLanguage` already persists via `didSet`. The explicit `queue.async { saveLanguage() }` in v1.0.5 duplicated the write and, when `setLanguage` was called off the main thread, could race ahead of the main-thread `@Published` update and store a stale value to UserDefaults.

## Test plan
- [x] Build passes
- [ ] Language change still persists across app relaunches