### PR TITLE
release: v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to SystemEQ for Mac are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] — 2026-05-16
+
+Follow-up to v1.0.5.
+
+### Fixed
+
+- `LocalizationManager.setLanguage(_:)` no longer issues a redundant `queue.async { saveLanguage() }`. The `@Published currentLanguage` already persists via its `didSet`; the extra write could race ahead of the main-thread update on background-thread callers and store a stale value to `UserDefaults` (#21)
+
 ## [1.0.5] — 2026-05-16
 
 Critical hang fix and a rendering regression in AutoEQ.

--- a/SystemEQ for Mac.xcodeproj/project.pbxproj
+++ b/SystemEQ for Mac.xcodeproj/project.pbxproj
@@ -356,7 +356,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4-playlist",
@@ -425,7 +425,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4-playlist",
 					"-lprojectM-4",
@@ -550,7 +550,7 @@
 					"@executable_path/../Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4",
@@ -593,7 +593,7 @@
 					"@executable_path/../Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/Vendor/projectM/lib";
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				OTHER_LDFLAGS = (
 					"-lprojectM-4",
 					"-lprojectM-4-playlist",
@@ -621,7 +621,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.denzam.SystemEQ.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -639,7 +639,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.denzam.SystemEQ.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;


### PR DESCRIPTION
## Summary
Releases the fix from #21 (drop redundant `saveLanguage()` in `setLanguage(_:)`) as v1.0.6.

- Bump `MARKETING_VERSION` to 1.0.6
- CHANGELOG entry for 1.0.6

## Test plan
- [x] Release build succeeds locally