### PR TITLE
chore: drop unused localization queue + backfill CHANGELOG links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,5 +87,10 @@ First public release.
 - Buffer-size mismatch between input and output AUHAL units
 - Real-time thread policy now applied to the audio callback thread
 
+[1.0.6]: https://github.com/denzam/SystemEQ-for-Mac/releases/tag/v1.0.6
+[1.0.5]: https://github.com/denzam/SystemEQ-for-Mac/releases/tag/v1.0.5
+[1.0.4]: https://github.com/denzam/SystemEQ-for-Mac/releases/tag/v1.0.4
+[1.0.3]: https://github.com/denzam/SystemEQ-for-Mac/releases/tag/v1.0.3
+[1.0.2]: https://github.com/denzam/SystemEQ-for-Mac/releases/tag/v1.0.2
 [1.0.1]: https://github.com/denzam/SystemEQ-for-Mac/releases/tag/v1.0.1
 [1.0.0]: https://github.com/denzam/SystemEQ-for-Mac/releases/tag/v1.0.0

--- a/SystemEQ for Mac/LocalizationManager.swift
+++ b/SystemEQ for Mac/LocalizationManager.swift
@@ -3823,8 +3823,6 @@ public final class LocalizationManager: ObservableObject {
     /// ... rest of the code remains the same ...
     public static let shared = LocalizationManager()
 
-    private let queue = DispatchQueue(label: "localization", qos: .userInitiated, attributes: .concurrent)
-
     @Published public var currentLanguage: AppLanguage {
         didSet {
             saveLanguage()


### PR DESCRIPTION
## Summary
Includes two localization and changelog maintenance fixes.

- Remove the now-unused `localization` `DispatchQueue` in `LocalizationManager` (no readers remain after #21)
- Backfill Keep a Changelog link definitions for 1.0.2 → 1.0.6 (1.0.0 / 1.0.1 already had them)

Code-only change. Will ship with the next release.

## Test plan
- [x] Release build passes locally
- [x] No remaining `queue` references in `LocalizationManager.swift`