### PR TITLE
a11y: keyboard nav for landing gallery

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -207,7 +207,8 @@
     cursor: pointer;
     transition: border-color 0.2s ease, transform 0.2s ease;
   }
-  .shot:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .shot:hover, .shot:focus-visible { border-color: var(--accent); transform: translateY(-2px); outline: none; }
+  .shot:focus-visible { box-shadow: 0 0 0 3px var(--accent); }
   .shot img, .shot video { aspect-ratio: 4/3; object-fit: cover; object-position: top; background: #000; width: 100%; display: block; }
   .shot-label { padding: 14px 16px; font-size: 13px; color: var(--text-dim); font-weight: 500; display: flex; align-items: center; justify-content: space-between; }
   .shot-label .live { background: var(--accent-soft); color: var(--accent); font-size: 11px; padding: 2px 8px; border-radius: 999px; font-weight: 600; letter-spacing: 0.02em; }
@@ -435,47 +436,47 @@
     <h2>See it in action</h2>
     <p class="sub">Click any screenshot to enlarge.</p>
     <div class="gallery">
-      <div class="shot" onclick="openLightbox('screenshots/01-main.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/01-main.png')">
         <img src="screenshots/01-main.png" alt="Main menu" loading="lazy" />
         <div class="shot-label">Main menu</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/02-eq-10.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/02-eq-10.png')">
         <img src="screenshots/02-eq-10.png" alt="10-band equalizer" loading="lazy" />
         <div class="shot-label">10-band equalizer</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/03-eq-31.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/03-eq-31.png')">
         <img src="screenshots/03-eq-31.png" alt="31-band equalizer" loading="lazy" />
         <div class="shot-label">31-band equalizer</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/04-calibration.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/04-calibration.png')">
         <img src="screenshots/04-calibration.png" alt="Equal loudness calibration" loading="lazy" />
         <div class="shot-label">Equal loudness calibration</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/05-room-tuning.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/05-room-tuning.png')">
         <img src="screenshots/05-room-tuning.png" alt="Subjective room tuning" loading="lazy" />
         <div class="shot-label">Subjective room tuning</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/06-resonance.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/06-resonance.png')">
         <img src="screenshots/06-resonance.png" alt="Resonance finder" loading="lazy" />
         <div class="shot-label">Resonance finder</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/07-autoeq.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/07-autoeq.png')">
         <img src="screenshots/07-autoeq.png" alt="AutoEQ preset library" loading="lazy" />
         <div class="shot-label">AutoEQ preset library</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/08-routing.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/08-routing.png')">
         <img src="screenshots/08-routing.png" alt="Audio routing" loading="lazy" />
         <div class="shot-label">Audio routing</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/09-settings.jpeg')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/09-settings.jpeg')">
         <img src="screenshots/09-settings.jpeg" alt="Settings" loading="lazy" />
         <div class="shot-label">Settings &amp; languages</div>
       </div>
-      <div class="shot" onclick="openLightbox('screenshots/10-visualizer.png')">
+      <div class="shot" tabindex="0" role="button" onclick="openLightbox('screenshots/10-visualizer.png')">
         <img src="screenshots/10-visualizer.png" alt="MilkDrop visualizer menu" loading="lazy" />
         <div class="shot-label">MilkDrop visualizer</div>
       </div>
-      <div class="shot" onclick="openVideo('screenshots/10-visualizer.mov')">
+      <div class="shot" tabindex="0" role="button" onclick="openVideo('screenshots/10-visualizer.mov')">
         <video src="screenshots/10-visualizer.mov" autoplay loop muted playsinline></video>
         <div class="shot-label">Visualizer in action <span class="live">LIVE · click for sound</span></div>
       </div>
@@ -584,7 +585,7 @@
     const lb = document.getElementById('lightbox');
     const img = document.getElementById('lightbox-img');
     const vid = document.getElementById('lightbox-video');
-    vid.style.display = 'none'; vid.pause(); vid.src = '';
+    vid.style.display = 'none'; vid.pause(); vid.removeAttribute('src'); vid.load();
     img.src = src; img.style.display = 'block';
     lb.classList.add('open');
     document.body.style.overflow = 'hidden';
@@ -593,9 +594,9 @@
     const lb = document.getElementById('lightbox');
     const img = document.getElementById('lightbox-img');
     const vid = document.getElementById('lightbox-video');
-    img.style.display = 'none'; img.src = '';
+    img.style.display = 'none'; img.removeAttribute('src');
     vid.src = src; vid.style.display = 'block';
-    vid.muted = false; vid.loop = true; vid.currentTime = 0;
+    vid.muted = false; vid.loop = true;
     lb.classList.add('open');
     document.body.style.overflow = 'hidden';
     vid.play().catch(() => { vid.muted = true; vid.play(); });
@@ -604,12 +605,17 @@
     if (e && e.target.tagName === 'VIDEO') return;
     const lb = document.getElementById('lightbox');
     const vid = document.getElementById('lightbox-video');
-    vid.pause(); vid.src = '';
+    vid.pause(); vid.removeAttribute('src'); vid.load();
     lb.classList.remove('open');
     document.body.style.overflow = '';
   }
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') closeLightbox();
+    if (e.key === 'Escape') {
+      closeLightbox();
+    } else if ((e.key === 'Enter' || e.key === ' ') && e.target.classList && e.target.classList.contains('shot')) {
+      e.preventDefault();
+      e.target.click();
+    }
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
Adds keyboard accessibility to `landing/index.html`:
- `tabindex="0"` + `role="button"` on `.shot` tiles
- `:focus-visible` outline matching `:hover` state
- Enter/Space keyboard activation
- Proper video cleanup via `removeAttribute('src') + load()` (instead of `src=""`)
- Removed redundant `currentTime = 0` before `play()`

## Test plan
- [ ] Tab through gallery — focus ring visible on each tile
- [ ] Press Enter/Space on a focused tile — lightbox opens
- [ ] Open visualizer video, close lightbox, reopen another tile — no stale video src warnings in console