### PR TITLE
fix(ci): correct paths in EQ database update workflow

### DIFF
--- a/.github/workflows/update-eq-database.yml
+++ b/.github/workflows/update-eq-database.yml
@@ -28,20 +28,18 @@ jobs:
           echo "AutoEQ cloned successfully"
       
       - name: Generate AutoEQ Index
-        working-directory: Scripts
         run: |
-          swift generate_autoeq_index.swift
+          swift Scripts/generate_autoeq_index.swift
           echo "Index generated"
-      
+
       - name: Build EQ Database
-        working-directory: Scripts
         run: |
-          swift build_eq_database.swift
+          swift Scripts/build_eq_database.swift
           echo "Database built"
-      
+
       - name: Copy database to Resources
         run: |
-          cp "Scripts/EQDatabase.db" "SystemEQ for Mac/Resources/EQDatabase.db"
+          cp "SystemEQ for Mac/EQDatabase.db" "SystemEQ for Mac/Resources/EQDatabase.db"
           echo "Database copied to Resources"
       
       - name: Get database stats

--- a/Scripts/generate_autoeq_index.swift
+++ b/Scripts/generate_autoeq_index.swift
@@ -110,7 +110,10 @@ func generateIndex() async throws {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let jsonData = try encoder.encode(entries)
     
-    let outputPath = FileManager.default.currentDirectoryPath + "/AutoEqIndex.json"
+    let cwd = FileManager.default.currentDirectoryPath
+    let scriptsDir = cwd + "/Scripts"
+    let dir = FileManager.default.fileExists(atPath: scriptsDir) ? scriptsDir : cwd
+    let outputPath = dir + "/AutoEqIndex.json"
     try jsonData.write(to: URL(fileURLWithPath: outputPath))
     
     print("✅ Індекс збережено в: \(outputPath)")

--- a/Scripts/generate_autoeq_index.swift
+++ b/Scripts/generate_autoeq_index.swift
@@ -110,11 +110,12 @@ func generateIndex() async throws {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let jsonData = try encoder.encode(entries)
     
-    let cwd = FileManager.default.currentDirectoryPath
-    let scriptsDir = cwd + "/Scripts"
-    let dir = FileManager.default.fileExists(atPath: scriptsDir) ? scriptsDir : cwd
-    let outputPath = dir + "/AutoEqIndex.json"
-    try jsonData.write(to: URL(fileURLWithPath: outputPath))
+    let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let scriptsDir = cwd.appendingPathComponent("Scripts")
+    let dir = FileManager.default.fileExists(atPath: scriptsDir.path) ? scriptsDir : cwd
+    let outputURL = dir.appendingPathComponent("AutoEqIndex.json")
+    let outputPath = outputURL.path
+    try jsonData.write(to: outputURL)
     
     print("✅ Індекс збережено в: \(outputPath)")
     print("📊 Розмір файлу: \(jsonData.count / 1024) KB")


### PR DESCRIPTION
## Проблема
Джоб **Update EQ Database** падав на кроці *Build EQ Database*:
\`\`\`
❌ Error: Error Domain=Cannot create database Code=-1
\`\`\`

## Справжня причина
Кроки *Generate* / *Build* бігли з \`working-directory: Scripts\`, але:
- `build_eq_database.swift` пише в `SystemEQ for Mac/EQDatabase.db` — від `Scripts/` це неіснуюча тека → `sqlite3_open` падає (це й була помилка).
- Дані `AutoEq/results/...` теж недосяжні з `Scripts/` (AutoEq клонується в корінь).

## Фікс
- Обидва кроки тепер біжать з кореня репо, шляхи скриптів кваліфіковані (`swift Scripts/...`).
- `generate_autoeq_index.swift` пише `AutoEqIndex.json` у `Scripts/`, щоб `build` його знаходив через існуючий fallback.
- Копіювання БД виправлено на `SystemEQ for Mac/EQDatabase.db`.